### PR TITLE
bug(examples): witness binary not executable in examples

### DIFF
--- a/examples/log4shell/Dockerfile
+++ b/examples/log4shell/Dockerfile
@@ -21,3 +21,4 @@ FROM maven:openjdk
 WORKDIR /src
 COPY --from=rekorbuilder /src/rekor/cmd/rekor-cli/rekor-cli /bin/rekor-cli
 COPY ./witness /bin/witness
+RUN chmod u+x /bin/witness

--- a/examples/solarwinds/Dockerfile
+++ b/examples/solarwinds/Dockerfile
@@ -25,3 +25,4 @@ RUN git clone https://github.com/testifysec/solarsploit.git && \
 COPY ./witness.yaml ./witness.yaml
 COPY ./main.go ./main.go
 COPY ./witness ./witness
+RUN chmod u+x ./witness


### PR DESCRIPTION
Not sure why this changed but on my fresh installation of my OS the
examples were throwing "permission denied" when trying to run the
witness binary. Simplest fix it to just make sure the user has execute
permissions for the binary after copying it into the image.

Signed-off-by: Mikhail Swift <mikhail@testifysec.com>