### PR TITLE
refactor: move attestor imports to pkg

### DIFF
--- a/cmd/witness/cmd/root.go
+++ b/cmd/witness/cmd/root.go
@@ -25,17 +25,6 @@ import (
 	"github.com/testifysec/witness/pkg/cryptoutil"
 	"github.com/testifysec/witness/pkg/log"
 	"github.com/testifysec/witness/pkg/spiffe"
-
-	// imported so their init functions run
-	_ "github.com/testifysec/witness/pkg/attestation/aws-iid"
-	_ "github.com/testifysec/witness/pkg/attestation/commandrun"
-	_ "github.com/testifysec/witness/pkg/attestation/environment"
-	_ "github.com/testifysec/witness/pkg/attestation/gcp-iit"
-	_ "github.com/testifysec/witness/pkg/attestation/git"
-	_ "github.com/testifysec/witness/pkg/attestation/gitlab"
-	_ "github.com/testifysec/witness/pkg/attestation/jwt"
-	_ "github.com/testifysec/witness/pkg/attestation/maven"
-	_ "github.com/testifysec/witness/pkg/attestation/oci"
 )
 
 var (

--- a/cmd/witness/cmd/sign.go
+++ b/cmd/witness/cmd/sign.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/testifysec/witness/cmd/witness/options"
-	witness "github.com/testifysec/witness/pkg"
+	"github.com/testifysec/witness/pkg"
 )
 
 func SignCmd() *cobra.Command {

--- a/cmd/witness/cmd/verify.go
+++ b/cmd/witness/cmd/verify.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/testifysec/witness/cmd/witness/options"
-	witness "github.com/testifysec/witness/pkg"
+	"github.com/testifysec/witness/pkg"
 	"github.com/testifysec/witness/pkg/cryptoutil"
 	"github.com/testifysec/witness/pkg/dsse"
 	"github.com/testifysec/witness/pkg/rekor"

--- a/pkg/attestors.go
+++ b/pkg/attestors.go
@@ -1,0 +1,28 @@
+// Copyright 2022 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package witness
+
+import (
+	// imported so their init functions run
+	_ "github.com/testifysec/witness/pkg/attestation/aws-iid"
+	_ "github.com/testifysec/witness/pkg/attestation/commandrun"
+	_ "github.com/testifysec/witness/pkg/attestation/environment"
+	_ "github.com/testifysec/witness/pkg/attestation/gcp-iit"
+	_ "github.com/testifysec/witness/pkg/attestation/git"
+	_ "github.com/testifysec/witness/pkg/attestation/gitlab"
+	_ "github.com/testifysec/witness/pkg/attestation/jwt"
+	_ "github.com/testifysec/witness/pkg/attestation/maven"
+	_ "github.com/testifysec/witness/pkg/attestation/oci"
+)


### PR DESCRIPTION
Moves all attestor imports to the witness package so anyone using
witness as a library will have all the stock attestors.

Signed-off-by: Mikhail Swift <mikhail@testifysec.com>


Fixes #148 