### PR TITLE
bug: ensure sarif and scorecard packages are imported

### DIFF
--- a/pkg/attestation/scorecard/scorecard.go
+++ b/pkg/attestation/scorecard/scorecard.go
@@ -108,7 +108,7 @@ func (a *Attestor) getCanidate(ctx *attestation.AttestationContext) error {
 			return fmt.Errorf("error reading file: %s", path)
 		}
 
-		//check to see if we can unmarshal into sarif type
+		//check to see if we can unmarshal into scorecard type
 		if err := json.Unmarshal(reportBytes, &a.Scorecard); err != nil {
 			fmt.Printf("error unmarshaling report: %s\n", err)
 			continue
@@ -119,7 +119,7 @@ func (a *Attestor) getCanidate(ctx *attestation.AttestationContext) error {
 
 		return nil
 	}
-	return fmt.Errorf("no sarif file found")
+	return fmt.Errorf("no scorecard file found")
 }
 
 func (a *Attestor) Subjects() map[string]cryptoutil.DigestSet {

--- a/pkg/attestors.go
+++ b/pkg/attestors.go
@@ -25,4 +25,6 @@ import (
 	_ "github.com/testifysec/witness/pkg/attestation/jwt"
 	_ "github.com/testifysec/witness/pkg/attestation/maven"
 	_ "github.com/testifysec/witness/pkg/attestation/oci"
+	_ "github.com/testifysec/witness/pkg/attestation/sarif"
+	_ "github.com/testifysec/witness/pkg/attestation/scorecard"
 )


### PR DESCRIPTION
The two newly added attestors were not imported so their init functions
would not have run. Also the scorecard attestor had references to sarif
incorrectly.

Signed-off-by: Mikhail Swift <mikhail@testifysec.com>