### PR TITLE
Bug/use dsse intermediates

### DIFF
--- a/pkg/verify.go
+++ b/pkg/verify.go
@@ -23,6 +23,7 @@ import (
 	"github.com/testifysec/witness/pkg/cryptoutil"
 	"github.com/testifysec/witness/pkg/dsse"
 	"github.com/testifysec/witness/pkg/intoto"
+	"github.com/testifysec/witness/pkg/log"
 	"github.com/testifysec/witness/pkg/policy"
 )
 
@@ -96,11 +97,13 @@ func Verify(policyEnvelope dsse.Envelope, policyVerifiers []cryptoutil.Verifier,
 	for _, env := range vo.collectionEnvelopes {
 		passedVerifiers, err := env.Verify(dsse.WithVerifiers(pubkeys), dsse.WithRoots(roots), dsse.WithIntermediates(intermediates))
 		if err != nil {
+			log.Debugf("(verify) skipping envelope: couldn't verify enveloper's signature with the policy's verifiers: %+v", err)
 			continue
 		}
 
 		statement := intoto.Statement{}
 		if err := json.Unmarshal(env.Payload, &statement); err != nil {
+			log.Debugf("(verify) skipping envelope: couldn't unmarshal envelope payload into in-toto statement: %+v", err)
 			continue
 		}
 


### PR DESCRIPTION
Please note that the Certificate and Intermediates fields on the DSSE
signature object are not spec standard fields and are custom to Witness
currently.

Currently the Witness run code is adding additional intermediates that
may be required to verify trust back to a root. This is useful when
using SPIFFE or other cases where an intermediate may be rotated fairly
frequently and cannot be embedded in the policy itself. However, the
witness verification code was not taking these additional intermediates
into account causing signatures to fail verification.

This change makes sure the DSSE code appropriately adds these
intermediates to the intermediate pool while verifying signatures with
x509 certificates.

Signed-off-by: Mikhail Swift <mikhail@testifysec.com>