### PR TITLE
bug: fix verification of attestations from rekor

### DIFF
--- a/pkg/cryptoutil/x509.go
+++ b/pkg/cryptoutil/x509.go
@@ -68,6 +68,7 @@ func (v *X509Verifier) BelongsToRoot(root *x509.Certificate) error {
 	_, err := v.cert.Verify(x509.VerifyOptions{
 		Roots:         rootPool,
 		Intermediates: intermediatePool,
+		CurrentTime:   v.trustedTime,
 	})
 
 	return err


### PR DESCRIPTION
Few different issues here

* Intermediates from rekor need to be base64 decoded before using them.
* Trusted time stamps were only being considered while parsing entries
  from rekor but not while verifying envelopes in witness.Verify. To get
  around this I added an option to attach a trusted time to a specific
  DSSE signature which makes sure this gets used when verifying the
  envelopes.

Signed-off-by: Mikhail Swift <mikhail@testifysec.com>