### PR TITLE
chore: add guards to scripts to check presence of required programs

### DIFF
--- a/examples/log4shell/build.sh
+++ b/examples/log4shell/build.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # Copyright 2022 The Witness Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+#!/bin/sh
 set -e
+
+DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+. "$DIR/../../test/common.sh"
+
+if ! checkprograms make docker ; then
+  exit 1
+fi
+
 
 printf "Building witness...\n"
 make -C ../../ clean build > /dev/null

--- a/examples/log4shell/find-affected-artifacts.sh
+++ b/examples/log4shell/find-affected-artifacts.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # Copyright 2022 The Witness Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#!/bin/sh
 set -e
+
+DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+. "$DIR/../../test/common.sh"
+
+if ! checkprograms awk sha256sum docker tr jq ; then
+  exit 1
+fi
 
 printf "\nFinding artifacts with log4j 1.2.17...\n"
 LOG4JHASH=$(echo -n dependency:log4j/log4j@1.2.17 | sha256sum | awk '{print $1}')

--- a/examples/log4shell/verify.sh
+++ b/examples/log4shell/verify.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # Copyright 2022 The Witness Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#!/bin/sh
 set -e
+
+DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+. "$DIR/../../test/common.sh"
+
+if ! checkprograms docker ; then
+  exit 1
+fi
+
 
 printf "\nVerifying policy on nonvulnerable package...\n"
 docker run --rm -it --net host -v "$(pwd):/src" -w /src/nonvuln witness-log4shell-demo witness verify -c ../witness.yaml --artifactfile target/my-app-1.0-SNAPSHOT.jar

--- a/examples/solarwinds/demo.sh
+++ b/examples/solarwinds/demo.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # Copyright 2021 The Witness Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#!/bin/sh
 set -e
+
+DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+. "$DIR/../../test/common.sh"
+
+if ! checkprograms make docker ; then
+  exit 1
+fi
 
 printf "Building witness...\n"
 make -C ../../ clean build > /dev/null

--- a/test/common.sh
+++ b/test/common.sh
@@ -1,4 +1,4 @@
-# Copyright 2021 The Witness Contributors
+# Copyright 2022 The Witness Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,20 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#! /bin/sh
-set -e
+#/bin/sh
+checkprograms() {
+  local result=0
+  for prog in "$@"
+  do
+    if ! command -v $prog > /dev/null; then
+      printf "$prog is required to run this script. please ensure if is installed and in your PATH\n"
+      result=1
+    fi
+  done
 
-DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-. "$DIR/common.sh"
-
-if ! checkprograms make ; then
-  exit 1
-fi
-
-
-
-make -C ../ build
-rm -f ./test-attestation.demo ./testapp ./policy-signed.json
-../bin/witness -c test.yaml run -- go build -o=testapp .
-../bin/witness -c test.yaml sign -f policy.json
-../bin/witness -c test.yaml verify
+  return $result
+}

--- a/test/test-oci.sh
+++ b/test/test-oci.sh
@@ -15,6 +15,13 @@
 #!/bin/sh
 set -e
 
+DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+. "$DIR/common.sh"
+
+if ! checkprograms make ko ; then
+  exit 1
+fi
+
 make -C ../ build
 rm -f out.tar
 KO_DOCKER_REPO=null ../bin/witness run -c test.yaml -a oci --trace=false -- ko publish --push=false --tarball out.tar .


### PR DESCRIPTION
Just adds some friendlier messages when running our test and example
scripts.  This came up when a developer tried to use the scripts and
encountered errors.

Signed-off-by: Mikhail Swift <mikhail@testifysec.com>