### PR TITLE
chore: add logging when an unknown flag is provided

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,7 +32,11 @@ func New() *cobra.Command {
 		Use:               "witness",
 		Short:             "Collect and verify attestations about your build environments",
 		DisableAutoGenTag: true,
+		SilenceErrors:     true,
 	}
+
+	logger := newLogger()
+	log.SetLogger(logger)
 
 	ro.AddFlags(cmd)
 	cmd.AddCommand(SignCmd())
@@ -40,7 +44,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(RunCmd())
 	cmd.AddCommand(CompletionCmd())
 	cmd.AddCommand(versionCmd())
-	cobra.OnInitialize(func() { preRoot(cmd, ro) })
+	cobra.OnInitialize(func() { preRoot(cmd, ro, logger) })
 	return cmd
 }
 
@@ -51,9 +55,7 @@ func Execute() {
 	}
 }
 
-func preRoot(cmd *cobra.Command, ro *options.RootOptions) {
-	logger := newLogger()
-	log.SetLogger(logger)
+func preRoot(cmd *cobra.Command, ro *options.RootOptions, logger *logrusLogger) {
 	if err := logger.SetLevel(ro.LogLevel); err != nil {
 		logger.l.Fatal(err)
 	}

--- a/cmd/verify_test.go
+++ b/cmd/verify_test.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,7 +42,7 @@ func Test_RunVerifyCA(t *testing.T) {
 		CertPath: leafcert.Name(),
 	}
 
-	caBytes, err := ioutil.ReadFile(ca.Name())
+	caBytes, err := os.ReadFile(ca.Name())
 	require.NoError(t, err)
 
 	policy := makepolicyCA(t, caBytes)


### PR DESCRIPTION
This is happening due to the order in which Cobra is running functions. Previously we were initializing our logging library in a Cobra OnInitialize function but this function gets run after Cobra has parsed the command line flags.

This resulted in our logging not being appropriately initialized so the error was being suppressed. By initializing our logger in the New function and only setting the level in the OnInitialize the unknown flag error gets logged appropriately.

Signed-off-by: Mikhail Swift <mikhail@testifysec.com>

Fixes #203 