### PR TITLE
chore: temporarily remove sigstore

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,10 +56,6 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - name: install cosign
-        uses: sigstore/cosign-installer@main
-        with:
-          cosign-release: 'v1.4.1'
       - uses: anchore/sbom-action/download-syft@v0.6.0
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
@@ -70,9 +66,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
-#      - uses: imjasonh/setup-ko@v0.4
-#      - name: build and release image
-#        run: cosign sign --oidc-issuer=https://token.actions.githubusercontent.com $(ko publish ./ --tags  ${{github.ref_name}})
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#          COSIGN_EXPERIMENTAL: 1

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,14 +25,6 @@ sboms:
   - artifacts: archive
   - id: source
     artifacts: source
-signs:
-  - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
-    signature: "${artifact}.sig"
-    certificate: "${artifact}.pem"
-    args: ["sign-blob", "--output-signature=${signature}", "--output-certificate=${certificate}", "${artifact}"]
-    artifacts: all
 changelog:
   use: github
   groups:


### PR DESCRIPTION
Currently errors from fulcio are breaking our release cycle. We will need to take a look at what is going on, but for now we're temporarily removing sigstore signing from our actions.

Signed-off-by: Mikhail Swift <mikhail@testifysec.com>