### PR TITLE
fix: Fulcio client id flag interpreted as OIDC issuer

### DIFF
--- a/cmd/keyloader.go
+++ b/cmd/keyloader.go
@@ -31,7 +31,7 @@ func loadSigners(ctx context.Context, ko options.KeyOptions) ([]cryptoutil.Signe
 
 	//Load key from fulcio
 	if ko.FulcioURL != "" {
-		fulcioSigner, err := fulcio.Signer(ctx, ko.FulcioURL, ko.OIDCClientID, ko.OIDCIssuer, ko.Token)
+		fulcioSigner, err := fulcio.Signer(ctx, ko.FulcioURL, ko.OIDCIssuer, ko.OIDCClientID, ko.Token)
 		if err != nil {
 			err := fmt.Errorf("failed to create signer from Fulcio: %w", err)
 			errors = append(errors, err)


### PR DESCRIPTION
I attempted to use `witness` with the Sigstore staging Fulcio and ran into an issue where the client id flag was being used as the OIDC issuer:

```
$ ./bin/witness run -a git -o att.json --fulcio https://fulcio.sigstage.dev --fulcio-oidc-issuer https://oauth2.sigstage.dev/auth --fulcio-oidc-client-id sigstore -s example

ERROR   failed to create signer from Fulcio: Get "sigstore/.well-known/openid-configuration": unsupported protocol scheme ""
ERROR   failed to load signers
```

The type signature of the function in [`go-witness`](https://github.com/testifysec/go-witness/blob/7332f6256a2bc49a68e8fdcf42d1d87fc7eaf6cb/signer/fulcio/fulcio.go#L48) has the issuer after the Fulcio URL, but `witness` is passing the client id instead.

```go
func Signer(ctx context.Context, fulcioURL string, oidcIssuer string, oidcClientID string, tokenOption string) (cryptoutil.Signer, error)
```

After swapping the order, I was able to sign an attestation with that same command. 

This [example](https://github.com/testifysec/witness-examples/blob/main/keyless-fulcio/README.md) references the out of order flags. 