### PR TITLE
fix: update goreleaser action to use go 1.20.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
       - uses: actions/cache@v2
         with:
           path: |


### PR DESCRIPTION
Same as https://github.com/testifysec/archivista/pull/54