### PR TITLE
fix: update github actions to use new fulcio url

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,14 +31,14 @@ jobs:
         run: go install github.com/praetorian-inc/gokart@latest
 
       - name: Static Analysis
-        uses: testifysec/witness-run-action@bdd82729b316d071606007cc9eecae326429caaf
+        uses: testifysec/witness-run-action@40aa4ef36fc431a37de7c3faebcb66513c03b934
         with:
           step: static-analysis
           attestations: "github sarif"
           command: gokart scan . -o sarif-results.json -s
 
       - name: Test
-        uses: testifysec/witness-run-action@bdd82729b316d071606007cc9eecae326429caaf
+        uses: testifysec/witness-run-action@40aa4ef36fc431a37de7c3faebcb66513c03b934
         with: 
           step: "test"
           attestations: "github"
@@ -90,7 +90,7 @@ jobs:
         run: go install github.com/goreleaser/goreleaser@latest
 
       - name: Run GoReleaser
-        uses: testifysec/witness-run-action@bdd82729b316d071606007cc9eecae326429caaf
+        uses: testifysec/witness-run-action@40aa4ef36fc431a37de7c3faebcb66513c03b934
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/test-github-token.yml
+++ b/.github/workflows/test-github-token.yml
@@ -25,6 +25,6 @@ jobs:
         run: make build
 
       - name: Test
-        run: ./bin/witness run -l debug -s test -a github --enable-archivist -o test.json --fulcio https://v1.fulcio.sigstore.dev --fulcio-oidc-client-id https://oauth2.sigstore.dev/auth --fulcio-oidc-issuer sigstore --timestamp-servers https://freetsa.org/tsr -- echo "hello" > test.txt
+        run: ./bin/witness run -l debug -s test -a github --enable-archivist -o test.json --fulcio https://fulcio.sigstore.dev --fulcio-oidc-client-id https://oauth2.sigstore.dev/auth --fulcio-oidc-issuer sigstore --timestamp-servers https://freetsa.org/tsr -- echo "hello" > test.txt
       - name: log output
         run: cat test.json


### PR DESCRIPTION
Updates to a newer version of the witness-run-action with the updated fulcio url as well as updates our tests to use the new fulcio url.