### PR TITLE
docs: Update key to signer-file-key-path in getting starter .witness.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ openssl pkey -in testkey.pem -pubout > testpub.pem
 ## .witness.yaml
 
 run:
-    key: testkey.pem
+    signer-file-key-path: testkey.pem
     trace: false
 verify:
     attestations:


### PR DESCRIPTION
A recent update changed the value for the key location from `key` to `signer-file-key-path`, this updates the Getting Started portion to reflect that change:
See https://github.com/testifysec/witness/pull/276/files#diff-a2d81e76a54ef2f17702a8b6de2fac6a61330f3585b3204f0463b3fa880c0f70L16
and current open issue: https://github.com/testifysec/witness/issues/287